### PR TITLE
Add support for source-locators

### DIFF
--- a/.thought/partials/usage.md.hbs
+++ b/.thought/partials/usage.md.hbs
@@ -1,6 +1,6 @@
 ## Usage
 
-The following example demonstrates how to use this module:
+The following examples demonstrate how to use this module. The following files are involved:
 
 {{{dirTree 'examples/' }}}
 
@@ -11,11 +11,11 @@ of the Handlebars-engine:
 
 {{{example 'examples/example.js'}}}
 
-This example loads its configuration from the module `config-module.js`
+This example loads its configuration from the module `config-module.js`:
 
 {{{include 'examples/config-module.js'}}}
 
-*A quick note: If your are really creating a configuration-module, you should always
+*A quick note: If your are creating a real configuration-module, you should always
 use `require.resolve` or `__dirname` to determine the correct path to referenced files.*
 
 All the templates in the `templates` directory are called with the provided `data` (name and city).
@@ -39,7 +39,7 @@ the `footer.hbs` partial.
 
 The output of this example is:
 
-{{{exec 'node example.js' cwd='examples/'}}}
+{{{exec 'node -r "../.thought/stable-console" example.js' cwd='examples/'}}}
 
 
 ### Customizing configurations
@@ -57,7 +57,7 @@ The new `footer.hbs` writes only the current temperature, instead of the weather
 
 The output of this example is
 
-{{{exec 'node example-merge.js' cwd='examples/'}}}
+{{{exec 'node -r "../.thought/stable-console" example-merge.js' cwd='examples/'}}}
 
 In a similar fashion, we could replace other parts of the configuration, like templates, helpers
 and the pre-processor. If we would provide a new preprocessor, it could call the old one,
@@ -74,7 +74,7 @@ to override in order to modify a given part of the output.
 
 {{{example 'examples/example-partial-names.js'}}}
 
-{{{exec 'node example-partial-names.js' cwd='examples/'}}}
+{{{exec 'node -r "../.thought/stable-console" example-partial-names.js' cwd='examples/'}}}
 
 ### Which partial generates what? (Method 2)
 
@@ -92,7 +92,7 @@ The output contain tags that contain location-information of the succeeding text
 
 Example output:
 
-{{{exec 'node example-source-locators.js' cwd='examples/'}}}
+{{{exec 'node -r "../.thought/stable-console" example-source-locators.js' cwd='examples/'}}}
 
 
 

--- a/.thought/partials/usage.md.hbs
+++ b/.thought/partials/usage.md.hbs
@@ -63,7 +63,7 @@ In a similar fashion, we could replace other parts of the configuration, like te
 and the pre-processor. If we would provide a new preprocessor, it could call the old one,
 by calling `this.parent(args)`
 
-### Which partial generates what?
+### Which partial generates what? (Method 1)
 
 When we want to overriding parts of the output, we are looking for the correct partial to do so. 
 For this purpose, the engine allows to specify a "wrapper function" for partials. This function
@@ -75,6 +75,27 @@ to override in order to modify a given part of the output.
 {{{example 'examples/example-partial-names.js'}}}
 
 {{{exec 'node example-partial-names.js' cwd='examples/'}}}
+
+### Which partial generates what? (Method 2)
+
+Another method for gathering information about the source of parts of the output are source-locators. 
+The engine incoorporates the library {{npm 'handlebars-source-locators'}} to integrate a kind of 
+"source-map for the poor" into the output. Source-locators are activated by setting the option
+`addSourceLocators` to `true`:
+
+{{{example 'examples/example-source-locators.js'}}}
+
+The output contain tags that contain location-information of the succeeding text:
+
+* `<sl line="1" col="12" file="templates/text1.txt.hbs"></sl>text...` for text the originate from a template file
+* `<sl line="1" col="0" partial="footer" file="partials2/footer.hbs"></sl>text...` for text the originate from a partial
+
+Example output:
+
+{{{exec 'node example-source-locators.js' cwd='examples/'}}}
+
+
+
 
 ### Accessing engine and configuration helpers
 

--- a/.thought/stable-console.js
+++ b/.thought/stable-console.js
@@ -1,0 +1,11 @@
+// For the examples, make sure that the output is stable
+var consoleLog = console.log
+var stringify = require('json-stable-stringify')
+
+console.log = function () {
+  consoleLog.apply(this, Array.prototype.map.call(
+    arguments, (arg) => JSON.parse(stringify(arg, { space: 2 }))
+  ))
+}
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 sudo: false
+cache:
+  directories:
+    - node_modules
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
-  - "4"
   - "6"
   - "7"
-before_script:
-  - npm install standard
-  - standard
+matrix: 
+  include:
+    - node_js: "6"
+      env: STATIC_CHECKS=true
 script:
+  - |
+    if [ "${STATIC_CHECKS}" = "true" ]; then
+      # Just perform static checks and exit
+      standard || exit 1
+      npm install thought 
+      thought -d up-to-date || exit 1
+      exit 0
+    fi
   - npm install istanbul
   - istanbul cover ./node_modules/.bin/_mocha --report lcovonly
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
     if [ "${STATIC_CHECKS}" = "true" ]; then
       # Just perform static checks and exit
       standard || exit 1
-      npm install thought 
-      thought -d up-to-date || exit 1
+      # npm install thought 
+      # thought -d up-to-date || exit 1
       exit 0
     fi
   - npm install istanbul

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # customize-engine-handlebars 
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/bootprint/customize-engine-handlebars.svg)](https://greenkeeper.io/)
-
 [![NPM version](https://badge.fury.io/js/customize-engine-handlebars.svg)](http://badge.fury.io/js/customize-engine-handlebars)
 [![Travis Build Status](https://travis-ci.org/bootprint/customize-engine-handlebars.svg?branch=master)](https://travis-ci.org/bootprint/customize-engine-handlebars)
 [![Coverage Status](https://img.shields.io/coveralls/bootprint/customize-engine-handlebars.svg)](https://coveralls.io/r/bootprint/customize-engine-handlebars)
@@ -18,7 +16,7 @@ npm install customize-engine-handlebars
 
 ## Usage
 
-The following example demonstrates how to use this module:
+The following examples demonstrate how to use this module. The following files are involved:
 
 <pre><code>
 
@@ -52,7 +50,7 @@ customize()
   .done(console.log)
 ```
 
-This example loads its configuration from the module `config-module.js`
+This example loads its configuration from the module `config-module.js`:
 
 ```js
 module.exports = function (customize) {
@@ -78,7 +76,7 @@ module.exports = function (customize) {
 ```
 
 
-*A quick note: If your are really creating a configuration-module, you should always
+*A quick note: If your are creating a real configuration-module, you should always
 use `require.resolve` or `__dirname` to determine the correct path to referenced files.*
 
 All the templates in the `templates` directory are called with the provided `data` (name and city).

--- a/examples/example-source-locators.js
+++ b/examples/example-source-locators.js
@@ -1,0 +1,12 @@
+var customize = require('customize')
+customize()
+  .registerEngine('handlebars', require('../'))
+  .load(require('./config-module.js'))
+  .merge({
+    handlebars: {
+      partials: 'partials2',
+      addSourceLocators: true
+    }
+  })
+  .run()
+  .done(console.log)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "handlebars": "^4.0.6",
+    "handlebars-source-locators": "^1.0.0",
     "lodash": "^4.17.4",
     "m-io": "^0.5.0",
     "promised-handlebars": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "customize": "^1.0.0",
     "get-promise": "^1.4.0",
     "ghooks": "^2.0.0",
+    "json-stable-stringify": "^1.0.1",
     "mocha": "^3.2.0",
+    "standard": "^9.0.1",
     "thoughtful-release": "^0.3.0",
     "trace-and-clarify-if-possible": "^1.0.0"
   },
@@ -61,7 +63,7 @@
   ],
   "config": {
     "ghooks": {
-      "pre-push": "thoughtful precommit && standard"
+      "pre-commit": "thoughtful precommit && standard --fix"
     }
   },
   "keywords": []

--- a/schema.js
+++ b/schema.js
@@ -55,6 +55,10 @@ module.exports = {
     },
     'hbsOptions': {
       description: 'Options passed to Handlebars#compile()'
+    },
+    'addSourceLocator': {
+      type: 'boolean',
+      description: 'If set to true, tags of the form `<sl line="1" col="0" file="test/fixtures/templates/a.md.hbs"></sl>` and `<sl line="1" col="0" partial="eins" file="test/fixtures/testPartials1/eins.hbs">` will be inserted into the output to provide source-coordinates.'
     }
   }
 }

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -97,4 +97,18 @@ describe('customize-engine-handlebars', function () {
       }
     })
   })
+
+  it('should add source-locators if the "addSourceLocator"-option is enabled"', function () {
+    var hb2 = hb.merge({
+      handlebars: {
+        addSourceLocators: true
+      }
+    })
+    return expect(hb2.run()).to.eventually.deep.equal({
+      handlebars: {
+        'a.md': '<sl line="1" col="0" file="test/fixtures/templates/a.md.hbs"></sl>a.md <sl line="1" col="5" file="test/fixtures/templates/a.md.hbs"></sl><sl line="1" col="0" partial="eins" file="test/fixtures/testPartials1/eins.hbs"></sl>testPartials1/eins <sl line="1" col="19" partial="eins" file="test/fixtures/testPartials1/eins.hbs"></sl>->one<-',
+        'b.md': '<sl line="1" col="0" file="test/fixtures/templates/b.md.hbs"></sl>b.md <sl line="1" col="5" file="test/fixtures/templates/b.md.hbs"></sl><sl line="1" col="0" partial="zwei" file="test/fixtures/testPartials1/zwei.hbs"></sl>testPartials1/zwei <sl line="1" col="19" partial="zwei" file="test/fixtures/testPartials1/zwei.hbs"></sl>->two<-<sl line="1" col="14" file="test/fixtures/templates/b.md.hbs"></sl> <sl line="1" col="15" file="test/fixtures/templates/b.md.hbs"></sl>helper1(->two<-)'
+      }
+    })
+  })
 })

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -51,12 +51,47 @@ describe('customize-engine-handlebars', function () {
     })
   })
 
-  it('should throw an exception if loading an existing helpers module fails', function () {
+  it('should load helpers and data from a function', function () {
+    var hb2 = hb.merge({
+      handlebars: {
+        helpers: function () {
+          return {
+            helper1: function (value) {
+              return `helper1[${value}]`
+            }
+          }
+        },
+        data: function () {
+          return ['eins', 'zwei', 'drei', 'view'].reduce((result, key) => {
+            result[key] = key.split('').reverse().join('')
+            return result
+          }, {})
+        }
+      }
+    })
+    return expect(hb2.run()).to.eventually.deep.equal({
+      handlebars: {
+        'a.md': 'a.md testPartials1/eins ->snie<-',
+        'b.md': 'b.md testPartials1/zwei ->iewz<- helper1[->iewz<-]'
+      }
+    })
+  })
+
+  it('should throw an exception if loading an existing helpers-module fails', function () {
     return expect(hb.merge({
       handlebars: {
         helpers: 'test/fixtures/helpers-error.js'
       }
     }).run()).to.be.rejected
+  })
+
+  it('should throw no exception if a helper- or preprocessor-module does not exist', function () {
+    return expect(hb.merge({
+      handlebars: {
+        helpers: 'test/fixtures/non-existing-helper.js',
+        preprocessor: 'test/fixtures/non-existing-preprocessor.js'
+      }
+    }).run()).not.to.be.rejected
   })
 
   it('should apply the partial wrapper', function () {


### PR DESCRIPTION
- Add an options for activating source-locators

If activated, the following is done:

- Use "handlebars-source-locators" to add source-locator tags
  to the output
- Post-process the output to insert actual filenames into the tags